### PR TITLE
Fixed error when there is no author | Changed Behaviour for Immersion Check

### DIFF
--- a/Ebook-Publisher.py
+++ b/Ebook-Publisher.py
@@ -245,6 +245,7 @@ parser.add_argument('--eol', help='end of line character for .txt output format,
 parser.add_argument('--chyoa-update', help='Checks if story already exists in output directory, and skips it if it has not been updated on the server since file was created.', action='store_true')
 parser.add_argument('--usr', help='Chyoa username to log in with.')
 parser.add_argument('--pswd', help='Chyoa password to log in with.')
+parser.add_argument('-c', help="Turns on immersion promping.  --quiet", action='store_true')
 args=parser.parse_args()
 
 #print(args.output_type)
@@ -290,7 +291,7 @@ Common.opf = args.output_type
 if Common.opf == None:
     Common.opf = ['txt']
 
-
+Common.chyoaImmersionCheck =args.c
 
 Common.mt = args.t
 

--- a/Site/Chyoa.py
+++ b/Site/Chyoa.py
@@ -96,6 +96,16 @@ class Chyoa:
             if Common.CheckDuplicate(self.title):
                 self.duplicate = True
                 return None
+
+        meta_tag = soup.find('p', class_='meta')
+        author_tag = meta_tag.find('a') if meta_tag else None
+        author_text = author_tag.get_text() if author_tag else "Unknown author"
+        
+        if self.backwards or self.partial:
+            self.authors.insert(0, author_text)
+        else:
+            self.authors.insert(0, author_text)
+
         
         if self.backwards or self.partial:
             self.authors.insert(0,soup.find('p', class_='meta').find('a').get_text())

--- a/Site/Chyoa.py
+++ b/Site/Chyoa.py
@@ -106,11 +106,6 @@ class Chyoa:
         else:
             self.authors.insert(0, author_text)
 
-        
-        if self.backwards or self.partial:
-            self.authors.insert(0,soup.find('p', class_='meta').find('a').get_text())
-        else:
-            self.authors.insert(0,soup.find('p', class_='meta').find('a').get_text())
         self.chapters.insert(0, soup.find('h1').get_text())
         self.summary=soup.find('p', attrs={'class': 'synopsis'}).get_text()
                 

--- a/Site/Chyoa.py
+++ b/Site/Chyoa.py
@@ -120,13 +120,16 @@ class Chyoa:
             with lock:
                 if Common.mt == True:
                     Common.quiet = True
-                for i in range(len(inputs)):
-                    print(self.title)
-                    print('Input immersion variable '+str(i)+' '+soup.find('label', attrs={'for':'c'+str(i)}).get_text()+' ('+inputs[i].get('placeholder')+') (Leave blank to keep placeholder name)')
-                    try:
-                        newname=input()
-                        self.renames.append(newname)
-                    except:
+                print(self.title)
+                for i in range(len(inputs)):                   
+                    if Common.chyoaImmersionCheck:
+                        print('Input immersion variable '+str(i)+' '+soup.find('label', attrs={'for':'c'+str(i)}).get_text()+' ('+inputs[i].get('placeholder')+') (Leave blank to keep placeholder name)')
+                        try:
+                            newname=input()
+                            self.renames.append(newname)
+                        except:
+                            self.renames.append('')
+                    else:
                         self.renames.append('')
                     self.oldnames.append(inputs[i].get('placeholder'))
                     if self.renames[i]=='':

--- a/Site/Common.py
+++ b/Site/Common.py
@@ -28,6 +28,9 @@ default_headers = {'User-Agent' : 'Mozilla/5.0 (Windows NT 6.1; Win64; x64)'}
 
 mt = False
 
+chyoaImmersionCheck= False
+
+
 urlDict=  {}
 
 def prnt(out, f=False):


### PR DESCRIPTION
Hi, I have changed two things. At leas the first one should be added as it introduced an fallback, the second one might be debatable.

1.) There are some Stories without a correct authors Tag. The author is not within `p.meta`, but somewhere else. 
This leads to Errors and inability to scrap the story.
I have now introduced a fallback to use "Unknown author" as the author if the author could not be extracted.

2.)
The Immersion Input is now disabled per default. Users can now use the arg: "-c" to activate it.